### PR TITLE
Directory expansion refactoring and tilde support

### DIFF
--- a/rc/edit-or-dir.kak
+++ b/rc/edit-or-dir.kak
@@ -2,11 +2,13 @@ define-command edit-or-dir -file-completion -params .. %{
     evaluate-commands %sh{
         echo "try %{ delete-buffer! *dir* }"
         arg="$1"
-        [ -z "$arg" ] && arg=$(pwd)
+        pwd=$(pwd)
+
+        # perform substitutions
+        [ -z "$arg" ] && arg="$pwd"
+
         if [ -d "$arg" ]; then
-            pwd=$(pwd)
-            case "$1" in
-                '')  dir="$pwd" ;;
+            case "$arg" in
                 /*)  dir="$arg" ;;
                 ..*) dir="$pwd/$arg"
                      prev="/${pwd##*/}<ret>;" ;;

--- a/rc/edit-or-dir.kak
+++ b/rc/edit-or-dir.kak
@@ -4,17 +4,16 @@ define-command edit-or-dir -file-completion -params .. %{
         arg="$1"
         pwd=$(pwd)
 
-        # perform substitutions
-        [ -z "$arg" ] && arg="$pwd"
-        [[ "$arg" == ~* ]] && arg="$HOME${arg:1}"
+        case "$arg" in
+            '')  dir="$pwd" ;;
+            ~*)  dir="$HOME${arg#~*}" ;;
+            /*)  dir="$arg" ;;
+            ..*) dir="$pwd/$arg"
+                 prev="/${pwd##*/}<ret>;" ;;
+            *)   dir="$pwd/$arg" ;;
+        esac
 
-        if [ -d "$arg" ]; then
-            case "$arg" in
-                /*)  dir="$arg" ;;
-                ..*) dir="$pwd/$arg"
-                     prev="/${pwd##*/}<ret>;" ;;
-                *)   dir="$pwd/$arg" ;;
-            esac
+        if [ -d "$dir" ]; then
             echo "change-directory %{$dir}"
             echo "edit-or-dir-display-dir %{$arg}"
             echo "try %{ execute-keys %{$prev}}"

--- a/rc/edit-or-dir.kak
+++ b/rc/edit-or-dir.kak
@@ -6,6 +6,7 @@ define-command edit-or-dir -file-completion -params .. %{
 
         # perform substitutions
         [ -z "$arg" ] && arg="$pwd"
+        [[ "$arg" == ~* ]] && arg="$HOME${arg:1}"
 
         if [ -d "$arg" ]; then
             case "$arg" in


### PR DESCRIPTION
This pull request cleans up some inconsistencies in directory expansion logic and adds support for tilde(`~`) expansion.

The main inconsistencies that caught my attention were the double handling of no arguments edge case and the use of `$1` for case statement, instead of the newly declared `$arg`.