### PR TITLE
Simplify directory display logic and hide ".." in root

### DIFF
--- a/rc/edit-or-dir.kak
+++ b/rc/edit-or-dir.kak
@@ -27,11 +27,11 @@ define-command -hidden -params 1 edit-or-dir-display-dir %{
     edit -scratch *dir*
     set-option window filetype 'file_select'
     evaluate-commands %sh{
-        keys="ls<space>$kak_opt_edit_or_dir_hidden<space>-p<space><ret>xd"
-        if [ -z $kak_opt_edit_or_dir_hidden ]; then
-            keys="!echo<space>../<space>&&<space> $keys gg"
+        keys="ls<space>$kak_opt_edit_or_dir_hidden<space>-p<space><ret>xdgg"
+        if [ "$(pwd)" = '/' ]; then
+            keys="!${keys}"
         else
-            keys="!"$keys"ggxd"
+            keys="!echo<space>../<space>&&<space> $keys"
         fi
         echo "execute-keys '$keys'"
     }
@@ -66,7 +66,7 @@ hook global WinSetOption filetype=file_select %{
 define-command -hidden edit-or-dir-toggle-hidden %{
     evaluate-commands %sh{
         if [ -z $kak_opt_edit_or_dir_hidden ]; then
-            echo "set-option global edit_or_dir_hidden '-a'"
+            echo "set-option global edit_or_dir_hidden '-A'"
         else
             echo "set-option global edit_or_dir_hidden ''"
         fi


### PR DESCRIPTION
This pull request suggests using `-A` ls flag for displaying hidden files. This allows sharing parent directory listing logic for both regular and hidden file modes.

This commit also includes modification which hides the parent directory listing from the root directory. 